### PR TITLE
Handle python versions 3.12.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setup(
         "dev": dev_reqs
     },
     tests_require=dev_reqs,
-    python_requires='>=3.6, <=3.12'
+    python_requires='>=3.6, <3.13'
 )


### PR DESCRIPTION
When I tried to install with poetry, it doesn't allow it since the python version is too strict.

If 3.12 is supported, it's safe to allow all versions under 3.13